### PR TITLE
[go] Add example code generator

### DIFF
--- a/go/helpers/BUILD.bazel
+++ b/go/helpers/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+  name = "go_default_library",
+  srcs = [
+    "camel.go",
+  ],
+  importpath = "github.com/eggybytes/protobuf-two-ways/go/helpers",
+  visibility = ["//go:__subpackages__"],
+)

--- a/go/helpers/LICENSE.md
+++ b/go/helpers/LICENSE.md
@@ -1,0 +1,27 @@
+Copyright 2010 The Go Authors.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/go/helpers/README.md
+++ b/go/helpers/README.md
@@ -1,0 +1,4 @@
+# helpers
+
+This package contains a single function, copied from the
+`github.com/golang/protobuf/protoc-gen-go/generator` (deprecated) package. Its LICENSE is referenced in its entirety in this package.

--- a/go/helpers/camel.go
+++ b/go/helpers/camel.go
@@ -1,0 +1,63 @@
+package helpers
+
+// Camel returns the CamelCased name.
+//
+// This was moved from the now deprecated github.com/golang/protobuf/protoc-gen-go/generator package
+//
+// If there is an interior underscore followed by a lower case letter,
+// drop the underscore and convert the letter to upper case.
+// There is a remote possibility of this rewrite causing a name collision,
+// but it's so remote we're prepared to pretend it's nonexistent - since the
+// C++ generator lowercases names, it's extremely unlikely to have two fields
+// with different capitalizations.
+// In short, _my_field_name_2 becomes XMyFieldName_2.
+func Camel(s string) string {
+	if s == "" {
+		return ""
+	}
+	t := make([]byte, 0, 32)
+	i := 0
+	if s[0] == '_' {
+		// Need a capital letter; drop the '_'.
+		t = append(t, 'X')
+		i++
+	}
+	// Invariant: if the next letter is lower case, it must be converted
+	// to upper case.
+	// That is, we process a word at a time, where words are marked by _ or
+	// upper case letter. Digits are treated as words.
+	for ; i < len(s); i++ {
+		c := s[i]
+		if c == '_' && i+1 < len(s) && isASCIILower(s[i+1]) {
+			continue // Skip the underscore in s.
+		}
+		if isASCIIDigit(c) {
+			t = append(t, c)
+			continue
+		}
+		// Assume we have a letter now - if not, it's a bogus identifier.
+		// The next word is a sequence of characters that must start upper case.
+		if isASCIILower(c) {
+			c ^= ' ' // Make it a capital letter.
+		}
+		t = append(t, c) // Guaranteed not lower case.
+		// Accept lower case sequence that follows.
+		for i+1 < len(s) && isASCIILower(s[i+1]) {
+			i++
+			t = append(t, s[i])
+		}
+	}
+	return string(t)
+}
+
+// And now lots of helper functions.
+
+// Is c an ASCII lower-case letter?
+func isASCIILower(c byte) bool {
+	return 'a' <= c && c <= 'z'
+}
+
+// Is c an ASCII digit?
+func isASCIIDigit(c byte) bool {
+	return '0' <= c && c <= '9'
+}

--- a/go/plugin/BUILD.bazel
+++ b/go/plugin/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//proto:compiler.bzl", "go_proto_compiler")
+
+go_library(
+  name = "go_default_library",
+  srcs = [
+    "egg.go",
+    "clientmock.go",
+    "main.go",
+  ],
+  importpath = "github.com/eggybytes/protobuf-two-ways/go/plugin",
+  visibility = ["//visibility:private"],
+  deps = [
+    "//go/helpers:go_default_library",
+    "//protos/annotations:annotations_proto_go_library",
+    "@org_golang_google_protobuf//proto:go_default_library",
+    "@org_golang_google_protobuf//compiler/protogen:go_default_library",
+    "@org_golang_google_protobuf//types/descriptorpb:go_default_library",
+  ],
+)
+
+go_binary(
+  name = "protoc-gen-custom-bin",
+  embed = [":go_default_library"],
+  visibility = ["//visibility:private"],
+)
+
+go_proto_compiler(
+  name = "protoc-gen-custom",
+  options = [
+    "paths=source_relative",
+  ],
+  plugin = ":protoc-gen-custom-bin",
+  suffix = ".pb.custom.go",
+  visibility = ["//visibility:public"],
+  deps = [
+    "@com_github_stretchr_testify//mock:go_default_library",
+  ],
+)

--- a/go/plugin/clientmock.go
+++ b/go/plugin/clientmock.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"strings"
+	"text/template"
+
+	"protos/annotations"
+
+	"github.com/eggybytes/protobuf-two-ways/go/helpers"
+
+	"google.golang.org/protobuf/compiler/protogen"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+var needsClientMockImports = map[string]bool{}
+
+// ClientMockGenerator generates a mock struct that satisfies a service's client interface
+type ClientMockGenerator struct{}
+
+var _ GeneratorIface = (*ClientMockGenerator)(nil)
+
+func NewClientMockGenerator() *ClientMockGenerator {
+	return &ClientMockGenerator{}
+}
+
+func (cmg *ClientMockGenerator) Generate(g *protogen.GeneratedFile, file *protogen.File) {
+	for _, pb := range file.Proto.GetService() {
+		if shouldGenerateClientMock(pb) {
+			needsClientMockImports[file.GeneratedFilenamePrefix] = true
+			cmg.generateClientMockFactory(g, pb)
+			cmg.generateClientMockMethods(g, pb, file)
+		}
+	}
+
+	if needsClientMockImports[file.GeneratedFilenamePrefix] {
+		g.QualifiedGoIdent(protogen.GoIdent{
+			GoName:       "context",
+			GoImportPath: "context",
+		})
+		g.QualifiedGoIdent(protogen.GoIdent{
+			GoName:       "mock",
+			GoImportPath: "github.com/stretchr/testify/mock",
+		})
+		g.QualifiedGoIdent(protogen.GoIdent{
+			GoName:       "grpc",
+			GoImportPath: "google.golang.org/grpc",
+		})
+	}
+}
+
+// shouldGenerateClientMock determines whether or not the message is tagged with
+// (client_mock=true)
+func shouldGenerateClientMock(pb *descriptorpb.ServiceDescriptorProto) bool {
+	if pb.GetOptions() == nil {
+		return false
+	}
+
+	if proto.GetExtension(pb.GetOptions(), annotations.E_ClientMock).(bool) {
+		return true
+	}
+
+	return false
+}
+
+func (cmg *ClientMockGenerator) generateClientMockFactory(g *protogen.GeneratedFile, pb *descriptorpb.ServiceDescriptorProto) {
+	factoryTemplate := `
+// Mock{{.ServiceName}}Client is a mock {{.ServiceName}}Client which
+// satisfies the {{.ServiceName}}Client interface.
+type Mock{{.ServiceName}}Client struct {
+	mock.Mock
+}
+
+func NewMock{{.ServiceName}}Client() *Mock{{.ServiceName}}Client {
+	return &Mock{{.ServiceName}}Client{}
+}
+`
+	tpl, err := template.New("factory").Parse(factoryTemplate)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	serviceName := helpers.Camel(pb.GetName())
+	var buf bytes.Buffer
+	err = tpl.Execute(&buf, struct {
+		ServiceName string
+	}{
+		ServiceName: serviceName,
+	})
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	g.P(buf.String())
+}
+
+func (cmg *ClientMockGenerator) generateClientMockMethods(g *protogen.GeneratedFile, pb *descriptorpb.ServiceDescriptorProto, file *protogen.File) {
+	methodTemplate := `
+func (c *Mock{{.ServiceName}}Client) {{.MethodName}}(ctx context.Context, in *{{.RequestType}}, opts ...grpc.CallOption) (*{{.ResponseType}}, error) {
+	args := c.Called(ctx, in)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*{{.ResponseType}}), args.Error(1)
+}
+`
+
+	for _, m := range pb.Method {
+		tpl, err := template.New("method").Parse(methodTemplate)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		origMethodName := m.GetName()
+		var buf bytes.Buffer
+		err = tpl.Execute(&buf, struct {
+			ServiceName  string
+			MethodName   string
+			RequestType  string
+			ResponseType string
+		}{
+			ServiceName:  helpers.Camel(pb.GetName()),
+			MethodName:   helpers.Camel(origMethodName),
+			RequestType:  typeName(file.GoPackageName, m.GetInputType()),
+			ResponseType: typeName(file.GoPackageName, m.GetOutputType()),
+		})
+
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		g.P(buf.String())
+	}
+}
+
+// Since the types we're referring to are in the same package, we drop the leading `.` and the package name
+func typeName(trimPackageName protogen.GoPackageName, typeName string) string {
+	return strings.TrimLeft(typeName, fmt.Sprintf(".%s", trimPackageName))
+}

--- a/go/plugin/egg.go
+++ b/go/plugin/egg.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"google.golang.org/protobuf/compiler/protogen"
+)
+
+// EggGenerator generates a package header and an egg
+type EggGenerator struct{}
+
+var _ GeneratorIface = (*EggGenerator)(nil)
+
+func NewEggGenerator() *EggGenerator {
+	return &EggGenerator{}
+}
+
+func (aeg *EggGenerator) Generate(g *protogen.GeneratedFile, file *protogen.File) {
+	g.P("package ", file.GoPackageName)
+	g.P()
+	g.P(`
+//             ████      
+//           ██░░░░██    
+//         ██░░░░░░░░██  
+//         ██░░░░░░░░██  
+//       ██░░░░░░░░░░░░██
+//       ██░░  ░░░░  ░░██
+//       ██░░░░    ░░░░██
+//         ██░░░░░░░░██  
+//           ████▓▓██
+`)
+}

--- a/go/plugin/main.go
+++ b/go/plugin/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"google.golang.org/protobuf/compiler/protogen"
+)
+
+type GeneratorIface interface {
+	Generate(g *protogen.GeneratedFile, file *protogen.File)
+}
+
+var plugins = []GeneratorIface{
+	NewEggGenerator(),
+	NewClientMockGenerator(),
+	// Add any other generators here
+}
+
+func main() {
+	var flags flag.FlagSet
+
+	protogen.Options{
+		ParamFunc: flags.Set,
+	}.Run(func(plugin *protogen.Plugin) error {
+		for _, f := range plugin.Files {
+			filename := fmt.Sprintf("%s.pb.custom.go", f.GeneratedFilenamePrefix)
+			g := plugin.NewGeneratedFile(filename, f.GoImportPath)
+
+			for _, p := range plugins {
+				p.Generate(g, f)
+			}
+		}
+
+		return nil
+	})
+}

--- a/protos/todo/BUILD.bazel
+++ b/protos/todo/BUILD.bazel
@@ -11,8 +11,9 @@ proto_library(
 )
 
 go_proto_library(
-  name = "organization_grpc_go_library",
+  name = "todo_grpc_go_library",
   compilers = [
+    "//go/plugin:protoc-gen-custom",
     "//protos:protoc-gen-go",
     "//protos:protoc-gen-grpc",
   ],


### PR DESCRIPTION
This PR adds an example protoc plugin that uses google.golang.org/protobuf/compiler/protogen to generate client mocks.