### PR TITLE
[go] Add reflection example

### DIFF
--- a/go/reflect/BUILD.bazel
+++ b/go/reflect/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+  name = "go_default_library",
+  srcs = ["clean.go"],
+  importpath = "github.com/eggybytes/protobuf-two-ways/go/reflect",
+  visibility = ["//visibility:public"],
+  deps = [
+    "//protos/annotations:annotations_proto_go_library",
+    "@org_golang_google_protobuf//proto:go_default_library",
+    "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
+    "@org_golang_google_protobuf//types/descriptorpb:go_default_library",
+  ],
+)
+
+go_test(
+  name = "go_default_test",
+  srcs = ["clean_test.go"],
+  embed = [":go_default_library"],
+  deps = [
+    "//protos/todo:todo_grpc_go_library",
+    "@com_github_stretchr_testify//assert:go_default_library",
+  ],
+)

--- a/go/reflect/clean.go
+++ b/go/reflect/clean.go
@@ -1,0 +1,69 @@
+package protobuf
+
+import (
+	"protos/annotations"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// Clean replaces every zero-valued primitive field with a nil value. It recurses into nested
+// messages, so cleans nested primitives also
+func Clean(pb proto.Message) proto.Message {
+	m := pb.ProtoReflect()
+
+	m.Range(cleanTopLevel(m))
+
+	return pb
+}
+
+func cleanTopLevel(m protoreflect.Message) func(protoreflect.FieldDescriptor, protoreflect.Value) bool {
+	return func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		// Skip cleaning any fields that are annotated with do_not_clean
+		opts := fd.Options().(*descriptorpb.FieldOptions)
+		if proto.GetExtension(opts, annotations.E_DoNotClean).(bool) {
+			return true
+		}
+
+		// Otherwise, set any empty primitive fields to nil. For non-primitive fields, recurse down
+		// one level with this function
+		switch kind := fd.Kind(); kind {
+		case protoreflect.BoolKind:
+			if fd.Default().Bool() == v.Bool() {
+				m.Clear(fd)
+			}
+		case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind, protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
+			if fd.Default().Int() == v.Int() {
+				m.Clear(fd)
+			}
+		case protoreflect.Uint32Kind, protoreflect.Fixed32Kind, protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+			if fd.Default().Uint() == v.Uint() {
+				m.Clear(fd)
+			}
+		case protoreflect.FloatKind, protoreflect.DoubleKind:
+			if fd.Default().Float() == v.Float() {
+				m.Clear(fd)
+			}
+		case protoreflect.StringKind:
+			if fd.Default().String() == v.String() {
+				m.Clear(fd)
+			}
+		case protoreflect.BytesKind:
+			if len(v.Bytes()) == 0 {
+				m.Clear(fd)
+			}
+		case protoreflect.EnumKind:
+			if fd.Default().Enum() == v.Enum() {
+				m.Clear(fd)
+			}
+		case protoreflect.GroupKind:
+			panic("groups are deprecated 🍳")
+		case protoreflect.MessageKind:
+			nested := v.Message()
+			nested.Range(cleanTopLevel(nested))
+		}
+
+		return true
+	}
+}

--- a/go/reflect/clean_test.go
+++ b/go/reflect/clean_test.go
@@ -1,0 +1,57 @@
+package protobuf
+
+import (
+	"testing"
+
+	"protos/todo"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestClean(t *testing.T) {
+	type args struct {
+		req proto.Message
+	}
+	type want struct {
+		req proto.Message
+	}
+	tests := []struct {
+		msg  string
+		args args
+		want want
+	}{
+		{
+			"top-level empty strings and zero values should be replaced with nil",
+			args{
+				&todo.CreateTodoRequest{
+					Name:       proto.String(""),
+					IsComplete: proto.Bool(false),
+				},
+			},
+			want{
+				&todo.CreateTodoRequest{},
+			},
+		},
+		{
+			"fields marked with do_not_clean do not get cleaned",
+			args{
+				&todo.CreateTodoRequest{
+					Name:        proto.String("do me"),
+					Description: proto.String(""),
+				},
+			},
+			want{
+				&todo.CreateTodoRequest{
+					Name:        proto.String("do me"),
+					Description: proto.String(""),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			assert.Equal(t, tt.want.req, Clean(tt.args.req))
+		})
+	}
+}


### PR DESCRIPTION
This PR adds an example of using google.golang.org/protobuf/reflect/protoreflect to sanitize a `proto.Message` at runtime